### PR TITLE
fix encode/1 spec

### DIFF
--- a/src/base62.erl
+++ b/src/base62.erl
@@ -24,7 +24,7 @@
 %% @doc Encode any data to base62 binary
 -spec encode(string()
              | integer()
-             | binary()) -> float().
+             | binary()) -> binary().
 encode(I) when is_integer(I) ->
     encode(integer_to_binary(I));
 encode(S) when is_list(S)->


### PR DESCRIPTION
Resolves dialyzer warning:

```
src/base62.erl
  51: The call erlang:binary_to_list(float()) breaks the contract (Binary) -> [byte()] when Binary :: binary()
```